### PR TITLE
wrap the fsockopen call into try/catch

### DIFF
--- a/src/LocalServerTestCase.php
+++ b/src/LocalServerTestCase.php
@@ -208,7 +208,11 @@ abstract class LocalServerTestCase extends \PHPUnit\Framework\TestCase
     private static function isPortAcceptingConnections($port)
     {
         clearstatcache();
-        $socket = @fsockopen(static::$hostname, $port);
+        try {
+            $socket = @fsockopen(static::$hostname, $port);
+        } catch (\Throwable $e) {
+            /* phpunit might have set convertWarningsToExceptions */
+        }
         if ($socket) {
             fclose($socket);
 


### PR DESCRIPTION
When PHPUnit is configured to convert warnings to exceptions, the
call whether a port is open and accepting connections may throw an
exception, causing the test setup to hang or the tests to fail in
obscure ways.

Wrapping the fsockopen call into a try/catch block and discarding
the exception on a failed connect avoids this.