### PR TITLE
Update for PHPUnit 8 and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provides an HTTP server test case for PHPUnit. The server is powered by PHP's bu
 
 ### Installing
 
-This library requires PHP 7.0 or newer. It _may_ run under PHP 5.6 but it is not supported.
+This library requires PHP 7.1 or newer. It will run with PHPUnit versions 7 and 8.
 
 ```
 composer require giberti/phpunit-local-server
@@ -35,7 +35,6 @@ use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 
 class Test extends LocalServerTestCase
 {
-
     public function testFoo() {
         static::createServerWithDocroot('./tests/localhost');
         $url = $this->getLocalServerUrl() . '/foo';
@@ -56,7 +55,6 @@ use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 
 class Test extends LocalServerTestCase
 {
-
     public static function setupBeforeClass() {
         static::createServerWithDocroot('./tests/localhost');
     }
@@ -79,46 +77,13 @@ class Test extends LocalServerTestCase
 
 ##### Modifying the server runtime version
 
-It's possible to run the server under a different PHP runtime than the version running your test suite. This can help with testing your code under multiple versions of PHP. In the example below, the server will start with the PHP 5.6 binary running on the test system.
+It's possible to run the server under a different PHP runtime than the version running your test suite. This can help with testing your code under multiple versions of PHP. In the example below, the server will start with the PHP 7.1 and 7.2 binary running on the test system.
 
 ```php
 use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 
-class Test56 extends LocalServerTestCase
-{
-
-    static $phpBinary = '/usr/local/bin/php56';
-
-    public function testFoo() {
-        static::createServerWithDocroot('./tests/localhost');
-
-        $url = $this->getLocalServer() . '/foo';
-        $content = file_get_contents($url);
-
-        $this->assertEquals('...', $content, 'Content mismatch');
-    }
-
-}
-
-class Test70 extends LocalServerTestCase
-{
-
-    static $phpBinary = '/usr/local/bin/php70';
-
-    public function testFoo() {
-        static::createServerWithDocroot('./tests/localhost');
-
-        $url = $this->getLocalServer() . '/foo';
-        $content = file_get_contents($url);
-
-        $this->assertEquals('...', $content, 'Content mismatch');
-    }
-
-}
-
 class Test71 extends LocalServerTestCase
 {
-
     static $phpBinary = '/usr/local/bin/php71';
 
     public function testFoo() {
@@ -129,9 +94,21 @@ class Test71 extends LocalServerTestCase
 
         $this->assertEquals('...', $content, 'Content mismatch');
     }
-
 }
 
+class Test72 extends LocalServerTestCase
+{
+    static $phpBinary = '/usr/local/bin/php72';
+
+    public function testFoo() {
+        static::createServerWithDocroot('./tests/localhost');
+
+        $url = $this->getLocalServer() . '/foo';
+        $content = file_get_contents($url);
+
+        $this->assertEquals('...', $content, 'Content mismatch');
+    }
+}
 ```
 
 ### Methods

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "ext-posix": "*",
-        "php": "^7.0",
+        "php": "^7.1",
         "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "require-dev": {},

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "ext-posix": "*",
         "php": "^7.0",
-        "phpunit/phpunit": "^6.0 || ^7.0"
+        "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "require-dev": {},
     "autoload": {

--- a/src/LocalServerTestCase.php
+++ b/src/LocalServerTestCase.php
@@ -237,7 +237,7 @@ abstract class LocalServerTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up any remaining servers at the end of the test execution
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         static::destroyServer();

--- a/tests/ConfigurationFailureTest.php
+++ b/tests/ConfigurationFailureTest.php
@@ -48,7 +48,7 @@ class ConfigurationFailureTest extends LocalServerTestCase
         static::createServerWithDocroot('./tests/localhost');
     }
 
-    public function setup()
+    public function setup(): void
     {
         parent::setup();
 
@@ -61,7 +61,7 @@ class ConfigurationFailureTest extends LocalServerTestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/ConfigurationOptimizationTest.php
+++ b/tests/ConfigurationOptimizationTest.php
@@ -2,7 +2,7 @@
 
 use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 
-class OptimizationTest extends LocalServerTestCase
+class ConfigurationOptimizationTest extends LocalServerTestCase
 {
 
     public function testReuseExistingServer()
@@ -48,7 +48,7 @@ class OptimizationTest extends LocalServerTestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         static::destroyServer();

--- a/tests/ServerDocrootTest.php
+++ b/tests/ServerDocrootTest.php
@@ -5,7 +5,7 @@ use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 class ServerDocrootTest extends LocalServerTestCase
 {
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         static::createServerWithDocroot('./tests/localhost');

--- a/tests/ServerRouterTest.php
+++ b/tests/ServerRouterTest.php
@@ -5,7 +5,7 @@ use Giberti\PHPUnitLocalServer\LocalServerTestCase;
 class ServerRouterTest extends LocalServerTestCase
 {
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         static::createServerWithRouter('./tests/localhost/router.php');


### PR DESCRIPTION
This addresses #3 by adding support for PHPUnit 8 and updating signatures for PHP 7.3. As part of supporting PHP 7.3, it was necessary to drop support for PHP 7.0 due to backwards incompatible signature changes, specifically adding the `void` return type.
