### PR TITLE
Remove support for PHP 7.1 and add 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 script:
   - composer install
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "ext-posix": "*",
-        "php": "^7.1",
+        "php": "^7.2",
         "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "require-dev": {},


### PR DESCRIPTION
Drop support for PHP 7.1. It reached EOL on December 1, 2019. 
Add support for TravisCI and PHP 7.4 which was released November 28, 2019.